### PR TITLE
fix: corporation entity name and function return

### DIFF
--- a/domain/src/main/kotlin/repository/CorporationRepository.kt
+++ b/domain/src/main/kotlin/repository/CorporationRepository.kt
@@ -1,17 +1,17 @@
 package repository
 
-import entity.Corporation
+import entity.CorporationEntity
 
 interface CorporationRepository {
 
-    fun save(bean: Corporation): String
+    fun save(bean: CorporationEntity): String
 
-    fun update(value: Corporation) : Boolean
+    fun update(value: CorporationEntity) : Boolean
 
     fun remove(corporationId: String) : Boolean
 
-    fun fetchById(corporationId: String) : Corporation?
+    fun fetchById(corporationId: String) : CorporationEntity?
 
-    fun fetchByDocument(document: String) : Corporation?
+    fun fetchByDocument(document: String) : CorporationEntity?
 
 }

--- a/domain/src/main/kotlin/service/CorporationService.kt
+++ b/domain/src/main/kotlin/service/CorporationService.kt
@@ -28,7 +28,7 @@ class CorporationService(val repository: CorporationRepository) {
         return repository.remove(id);
     }
 
-    private fun createCorporationEntity(corporationModel: CreateCorporationRequestModel){
+    private fun createCorporationEntity(corporationModel: CreateCorporationRequestModel) : CorporationEntity {
         val corporationEntity = CorporationEntity(corporationModel.id,
             corporationModel.name,
             corporationModel.document,
@@ -37,9 +37,11 @@ class CorporationService(val repository: CorporationRepository) {
         corporationEntity.email = corporationModel.email
         corporationEntity.phone = corporationModel.phone
         corporationEntity.active = corporationModel.active
+
+        return corporationEntity
     }
 
-    private fun createCorporationEntity(corporationModel: UpdateCorporationRequestModel){
+    private fun createCorporationEntity(corporationModel: UpdateCorporationRequestModel) : CorporationEntity {
         val corporationEntity = CorporationEntity(corporationModel.id,
             corporationModel.name,
             corporationModel.document,
@@ -48,6 +50,8 @@ class CorporationService(val repository: CorporationRepository) {
         corporationEntity.email = corporationModel.email
         corporationEntity.phone = corporationModel.phone
         corporationEntity.active = corporationModel.active
+
+        return corporationEntity
     }
 
     private fun createCorporationResponseModel(corporationEntity: CorporationEntity?): CorporationResponseModel?{


### PR DESCRIPTION
Corrigi só o nome da `CorporationEntity`, que estava só o `Corporation` e também o retorno das funções que não estava retornando a entity.